### PR TITLE
Provide a legacy formatter

### DIFF
--- a/AltiumNetlistGen.py
+++ b/AltiumNetlistGen.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Aug 30, 2018 at 05:02 PM -0400
+# Last Change: Fri Aug 31, 2018 at 12:07 AM -0400
 
 from pathlib import Path
 
 from pyUTM.io import XLReader, write_to_csv
+from pyUTM.io import legacy_csv_line_pt
 from pyUTM.selection import SelectorPD, RulePD
 from pyUTM.datatype import BrkStr
 
@@ -244,4 +245,4 @@ print('====WARNINGS for PigTail====')
 pt_result = PtSelector.do()
 
 # Finally, write to csv file
-write_to_csv(pt_result_output_filename, pt_result)
+write_to_csv(pt_result_output_filename, pt_result, formatter=legacy_csv_line_pt)

--- a/AltiumNetlistGen.py
+++ b/AltiumNetlistGen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Aug 30, 2018 at 03:49 PM -0400
+# Last Change: Thu Aug 30, 2018 at 05:02 PM -0400
 
 from pathlib import Path
 
@@ -244,4 +244,4 @@ print('====WARNINGS for PigTail====')
 pt_result = PtSelector.do()
 
 # Finally, write to csv file
-# write_to_csv(pt_result_output_filename, pt_result)
+write_to_csv(pt_result_output_filename, pt_result)

--- a/pyUTM/io.py
+++ b/pyUTM/io.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Wed Aug 29, 2018 at 10:52 PM -0400
+# Last Change: Thu Aug 30, 2018 at 05:04 PM -0400
 
 import openpyxl
 import re
@@ -9,6 +9,7 @@ import re
 from pyparsing import nestedExpr
 
 from pyUTM.datatype import range, ColNum
+from pyUTM.selection import RulePD
 
 
 ##################
@@ -17,18 +18,28 @@ from pyUTM.datatype import range, ColNum
 
 def write_to_csv(filename, data):
     with open(filename, 'w') as f:
-        for entry in data:
-            f.write(generate_csv_line(entry) + '\n')
+        for node in data.keys():
+            attr = data[node]
+            f.write(generate_csv_line(node, attr) + '\n')
 
 
-def generate_csv_line(entry, ignore_empty=True):
+def generate_csv_line(node, attr):
     s = ''
-    for cell in entry:
-        if cell is not None:
-            s += str(cell)
-        elif not ignore_empty:
-            s += 'None'
+
+    if node.NET_NAME is None:
+        s += attr
+    elif attr is not None:
+        net_head, net_tail = node.NET_NAME.split('_', 1)
+        s += (net_head + attr + net_tail)
+    else:
+        s += node.NET_NAME
+    s += ','
+
+    for item in node[1:]:
+        if item is not None:
+            s += item
         s += ','
+
     # Remove the trailing ','
     return s[:-1]
 

--- a/pyUTM/io.py
+++ b/pyUTM/io.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Aug 30, 2018 at 05:04 PM -0400
+# Last Change: Thu Aug 30, 2018 at 05:14 PM -0400
 
 import openpyxl
 import re
@@ -15,13 +15,6 @@ from pyUTM.selection import RulePD
 ##################
 # For CSV output #
 ##################
-
-def write_to_csv(filename, data):
-    with open(filename, 'w') as f:
-        for node in data.keys():
-            attr = data[node]
-            f.write(generate_csv_line(node, attr) + '\n')
-
 
 def generate_csv_line(node, attr):
     s = ''
@@ -42,6 +35,13 @@ def generate_csv_line(node, attr):
 
     # Remove the trailing ','
     return s[:-1]
+
+
+def write_to_csv(filename, data, formatter=generate_csv_line):
+    with open(filename, 'w') as f:
+        for node in data.keys():
+            attr = data[node]
+            f.write(formatter(node, attr) + '\n')
 
 
 #######################

--- a/pyUTM/io.py
+++ b/pyUTM/io.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Fri Aug 31, 2018 at 12:12 AM -0400
+# Last Change: Fri Aug 31, 2018 at 12:18 AM -0400
 
 import openpyxl
 import re
@@ -44,7 +44,12 @@ def legacy_csv_line_pt(node, attr):
     if node.NET_NAME is None:
         s += attr
 
-    elif attr is not None:
+    elif attr is None and 'JD' not in node.NET_NAME:
+        s += node.NET_NAME
+
+    else:
+        attr = '_' if attr is None else attr
+
         try:
             net_head, net_body, net_tail = node.NET_NAME.split('_', 2)
 
@@ -62,7 +67,7 @@ def legacy_csv_line_pt(node, attr):
                 if node.PT in net_body:
                     net_body += RulePD.PADDING(node.PT_PIN)
 
-            s += (net_head + attr + net_body + net_tail)
+            s += (net_head + attr + net_body + '_' + net_tail)
 
         except Exception:
             net_head, net_tail = node.NET_NAME.split('_', 1)

--- a/pyUTM/selection.py
+++ b/pyUTM/selection.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Wed Aug 29, 2018 at 04:20 PM -0400
+# Last Change: Thu Aug 30, 2018 at 03:13 PM -0400
 
 import re
 import abc
+
+from pyUTM.datatype import NetNode
 
 
 ########################
@@ -51,14 +53,16 @@ class Rule(metaclass=abc.ABCMeta):
 
 class SelectorPD(Selector):
     def do(self):
-        processed_dataset = []
+        processed_dataset = {}
 
         for connector_idx in range(0, len(self.full_dataset)):
             for entry in self.full_dataset[connector_idx]:
                 for rule in self.rules:
                     result = rule.filter((entry, connector_idx))
                     if result is not None:
-                        processed_dataset.append(result)
+                        args, attr = result
+                        key = NetNode(**args)
+                        processed_dataset[key] = attr
                         break
 
         return processed_dataset


### PR DESCRIPTION
A legacy csv formatter `legacy_csv_line_pt` is provided in `pyUTM.io` so that the output csv file is identical to the old (`v0.3`) one. 

I verified this by diff the two.