### PR TITLE
Fix two cases for DCB-None or None-PT netname inconsistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+env:
+    - IN_TRAVIS_CI=yes
+
 matrix:
     include:
         - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
+python: 3.7
+dist: xenial
+sudo: true
 
 env:
     - IN_TRAVIS_CI=yes
-
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial
-          sudo: true
 
 cache: pip
 

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 01:30 AM -0400
+# Last Change: Thu Sep 20, 2018 at 11:25 AM -0400
 
 from pathlib import Path
 from os import environ
@@ -155,13 +155,16 @@ class RuleNet_One_To_N(RuleNet):
         number_replacement_rules = ['ZERO', 'ONE', 'TWO', 'THREE', 'FOUR',
                                     'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE']
         splitted = node_name.split('JPU')
-
         if len(splitted) == 2:
             name, num = splitted
             return name + '_' + number_replacement_rules[int(num)]
 
-        else:
-            return node_name
+        splitted = node_name.split('JPL')
+        if len(splitted) == 2:
+            name, num = splitted
+            return name + '_' + number_replacement_rules[int(num)]
+
+        return node_name
 
 
 net_rules = [

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 11:25 AM -0400
+# Last Change: Thu Sep 20, 2018 at 11:55 AM -0400
 
 from pathlib import Path
 from os import environ
@@ -144,6 +144,12 @@ class RuleNet_One_To_N(RuleNet):
 
                 if node1 in all_nodes_list:
                     for node in all_nodes_list:
+                        # NOTE: If a connector includes 'JS_PT', assuming it is
+                        # jumped to another correct component.
+                        if 'JS_PT' in node:
+                            return True
+
+                    for node in all_nodes_list:
                         if node2 in node:
                             return True
 
@@ -154,6 +160,7 @@ class RuleNet_One_To_N(RuleNet):
     def replace_arabic_number_to_english(node_name):
         number_replacement_rules = ['ZERO', 'ONE', 'TWO', 'THREE', 'FOUR',
                                     'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE']
+
         splitted = node_name.split('JPU')
         if len(splitted) == 2:
             name, num = splitted

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 11:55 AM -0400
+# Last Change: Thu Sep 20, 2018 at 12:00 PM -0400
 
 from pathlib import Path
 from os import environ
@@ -137,7 +137,9 @@ class RuleNet_One_To_N(RuleNet):
             _, _, reference_signal_id = netname_by_zishuo.split('_', 2)
 
             if signal_id.replace('EAST_LV', 'WEST_LV') == reference_signal_id \
-                    or signal_id == reference_signal_id:
+                    or signal_id == reference_signal_id \
+                    or ('LV_RETURN' in signal_id and 'LV_RETURN' in
+                        reference_signal_id):
                 all_nodes_list = \
                     list(zip(*self.netlist_dict[netname_by_tom]))[0]
                 node2 = self.replace_arabic_number_to_english(node2)

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Wed Sep 19, 2018 at 03:33 PM -0400
+# Last Change: Wed Sep 19, 2018 at 05:30 PM -0400
 
 from pathlib import Path
+from os import environ
 
-from pyUTM.io import PcadReaderCached
+from pyUTM.io import PcadReader, PcadReaderCached
 from pyUTM.selection import SelectorNet, RuleNet
 from pyUTM.datatype import GenericNetNode
 from AltiumNetlistGen import input_dir, pt_result, dcb_result
@@ -18,7 +19,12 @@ cache_dir = 'cache'
 # Read info from backplane netlist #
 ####################################
 
-NetReader = PcadReaderCached(cache_dir, netlist)
+if 'IN_TRAVIS_CI' in environ:
+    print('Travis CI builder detected. Skip caching.')
+    NetReader = PcadReader(netlist)
+else:
+    NetReader = PcadReaderCached(cache_dir, netlist)
+
 netlist_dict = NetReader.read()
 netlist_list = list(netlist_dict.keys())
 

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 01:10 AM -0400
+# Last Change: Thu Sep 20, 2018 at 01:30 AM -0400
 
 from pathlib import Path
 from os import environ
@@ -64,9 +64,7 @@ class RuleNet_DCB_PT_NetName_Inconsistent(RuleNet):
 
 class RuleNet_DCB_Or_PT_NetName_Inconsistent(RuleNet):
     def match(self, node):
-        if self.reference[node]['NETNAME'] != \
-                self.node_dict[node]['NETNAME'].replace('EAST_LV', 'WEST_LV'):
-                # ^Seems that 'WEST_LV' and 'EAST_LV' are always equivalent
+        if self.reference[node]['NETNAME'] != self.node_dict[node]['NETNAME']:
             return True
         else:
             return False
@@ -80,6 +78,16 @@ class RuleNet_DCB_Or_PT_NetName_Inconsistent(RuleNet):
                 self.node_to_str(node)
             )
         )
+
+
+class RuleNet_DCB_Or_PT_NetName_Equal_Cavalier(RuleNet):
+    def match(self, node):
+        if self.reference[node]['NETNAME'] == \
+                self.node_dict[node]['NETNAME'].replace('EAST_LV', 'WEST_LV'):
+                # ^Seems that 'WEST_LV' and 'EAST_LV' are always equivalent
+            return True
+        else:
+            return False
 
 
 class RuleNet_Node_NotIn(RuleNet):
@@ -128,7 +136,8 @@ class RuleNet_One_To_N(RuleNet):
             node1, node2, signal_id = netname_by_tom.split('_', 2)
             _, _, reference_signal_id = netname_by_zishuo.split('_', 2)
 
-            if signal_id == reference_signal_id:
+            if signal_id.replace('EAST_LV', 'WEST_LV') == reference_signal_id \
+                    or signal_id == reference_signal_id:
                 all_nodes_list = \
                     list(zip(*self.netlist_dict[netname_by_tom]))[0]
                 node2 = self.replace_arabic_number_to_english(node2)
@@ -160,8 +169,8 @@ net_rules = [
     RuleNet_Node_NotIn(node_dict, node_list, pt_result),
     RuleNet_DCB_PT_NetName_Inconsistent(node_dict, node_list, pt_result),
     RuleNet_One_To_N(netlist_dict, node_dict, node_list, pt_result),
-    RuleNet_DCB_Or_PT_NetName_Inconsistent(
-        node_dict, node_list, pt_result),
+    RuleNet_DCB_Or_PT_NetName_Equal_Cavalier(node_dict, node_list, pt_result),
+    RuleNet_DCB_Or_PT_NetName_Inconsistent(node_dict, node_list, pt_result),
 ]
 
 

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 12:56 AM -0400
+# Last Change: Thu Sep 20, 2018 at 01:10 AM -0400
 
 from pathlib import Path
 from os import environ
@@ -65,7 +65,8 @@ class RuleNet_DCB_PT_NetName_Inconsistent(RuleNet):
 class RuleNet_DCB_Or_PT_NetName_Inconsistent(RuleNet):
     def match(self, node):
         if self.reference[node]['NETNAME'] != \
-                self.node_dict[node]['NETNAME']:
+                self.node_dict[node]['NETNAME'].replace('EAST_LV', 'WEST_LV'):
+                # ^Seems that 'WEST_LV' and 'EAST_LV' are always equivalent
             return True
         else:
             return False

--- a/NetlistCheck.py
+++ b/NetlistCheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Thu Sep 20, 2018 at 12:20 AM -0400
+# Last Change: Thu Sep 20, 2018 at 12:56 AM -0400
 
 from pathlib import Path
 from os import environ
@@ -130,10 +130,28 @@ class RuleNet_One_To_N(RuleNet):
             if signal_id == reference_signal_id:
                 all_nodes_list = \
                     list(zip(*self.netlist_dict[netname_by_tom]))[0]
-                if node1 in all_nodes_list and node2 in all_nodes_list:
-                    return True
+                node2 = self.replace_arabic_number_to_english(node2)
+
+                if node1 in all_nodes_list:
+                    for node in all_nodes_list:
+                        if node2 in node:
+                            return True
 
         return False
+
+    # This is needed because Tom is cavalier in picking names.
+    @staticmethod
+    def replace_arabic_number_to_english(node_name):
+        number_replacement_rules = ['ZERO', 'ONE', 'TWO', 'THREE', 'FOUR',
+                                    'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE']
+        splitted = node_name.split('JPU')
+
+        if len(splitted) == 2:
+            name, num = splitted
+            return name + '_' + number_replacement_rules[int(num)]
+
+        else:
+            return node_name
 
 
 net_rules = [

--- a/pyUTM/selection.py
+++ b/pyUTM/selection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # License: MIT
-# Last Change: Wed Sep 19, 2018 at 01:12 PM -0400
+# Last Change: Wed Sep 19, 2018 at 06:17 PM -0400
 
 import re
 import abc
@@ -147,7 +147,10 @@ class SelectorNet(Selector):
         for node in self.full_dataset.keys():
             for rule in self.rules:
                 result = rule.filter(node)
-                if result is not None:
+                if result is False:
+                    break
+
+                elif result is not None:
                     section, entry = result
                     processed_dataset[section].append(entry)
                     break
@@ -156,9 +159,9 @@ class SelectorNet(Selector):
 
 
 class RuleNet(Rule):
-    def __init__(self, netlist_dict, netlist_list, reference):
-        self.netlist_dict = netlist_dict
-        self.netlist_list = netlist_list
+    def __init__(self, node_dict, node_list, reference):
+        self.node_dict = node_dict
+        self.node_list = node_list
         self.reference = reference
 
     def filter(self, node):
@@ -166,7 +169,7 @@ class RuleNet(Rule):
             return self.process(node)
 
     def process(self, node):
-        pass
+        return False
 
     def node_to_str(self, node):
         attrs = self.node_data_properties(node)


### PR DESCRIPTION
* `EAST_LV` and `WEST_LV` are no longer differentiated.
* 1-to-n are properly resolved (have to replace `JPL0` -> `JPL_ZERO`, due to Tom's naming).